### PR TITLE
feat: implement git revert command and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,9 @@ git push <remote> <refspec>
 ```
 
 `push`를 통해 `commit`된 변경사항을 remote에 반영한다. 
+
+## revert
+```shell
+git revert
+```
+`revert`를 통해 `commit`을 되돌린다. 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,9 +3,11 @@ pub mod commit;
 pub mod init;
 pub mod log;
 pub mod push;
+pub mod revert;
 
 pub use add::git_add;
 pub use commit::git_commit;
 pub use init::git_init;
 pub use log::git_log;
 pub use push::git_push;
+pub use revert::git_revert;

--- a/src/commands/revert.rs
+++ b/src/commands/revert.rs
@@ -1,0 +1,52 @@
+use git2::build::CheckoutBuilder;
+use git2::{ApplyLocation, Oid, Repository};
+
+pub fn git_revert(commit_id: &str) -> Result<(), git2::Error> {
+    let repo = Repository::open(".")?;
+
+    // 타켓 커밋을 Oid로 변환후 찾기
+    let target_oid = Oid::from_str(commit_id)?;
+    let target_commit = repo.find_commit(target_oid)?;
+
+    // 타켓 커밋의 첫번째 부모를 찾기
+    let parent_commit = target_commit.parent(0)?;
+
+    // 타켓과 부모의 트리 객체 가져오기
+    let target_tree = target_commit.tree()?;
+    let parent_tree = parent_commit.tree()?;
+
+    // 부모와 타겟의 순서를 바꿔 역방향 diff를 만들면 타켓 커밋의 변경사항을 되돌리는 패치가 생성
+    let diff = repo.diff_tree_to_tree(Some(&target_tree), Some(&parent_tree), None)?;
+
+    repo.apply(&diff, ApplyLocation::Index, None)?;
+
+    let mut idx = repo.index()?;
+    let tree_id = idx.write_tree()?;
+    let tree = repo.find_tree(tree_id)?;
+
+    // 작업 디렉토리 업데이트
+    let mut checkout = CheckoutBuilder::new();
+    repo.checkout_index(Some(&mut idx), Some(&mut checkout))?;
+
+    let head_oid = repo.refname_to_id("HEAD")?;
+    let head_commit = repo.find_commit(head_oid)?;
+
+    let sig = repo.signature()?;
+
+    // 커밋 메시지에 Revert 추가
+    let summary = target_commit.summary().unwrap_or("");
+    let commit_msg = format!("Revert \"{}\"", summary);
+
+    repo.commit(
+        Some("HEAD"),
+        &sig,
+        &sig,
+        &commit_msg,
+        &tree,
+        &[&head_commit],
+    )?;
+
+    println!("Revert commit created: {}", commit_msg);
+
+    Ok(())
+}


### PR DESCRIPTION
git revert command 생성 및 테스트 추가

### 고민해야할 부분
* 현재 revert commit 생성시 새로 구현한 commit 메서드를 사용하지 않고 git2 메서드를 직접사용하고 있다.
* 구현한 commit 메서드를 사용하는게 좋을지 아니면 git2 메서드를 그냥 바로 사용하는게 나을지 고민하기.


closes: #13
ref: https://docs.rs/git2/latest/git2/struct.Repository.html#method.revert

